### PR TITLE
Bulk methods behaves nicely when empty array is passed as keys argument

### DIFF
--- a/lib/bloomrb.rb
+++ b/lib/bloomrb.rb
@@ -48,14 +48,20 @@ class Bloomrb
   end
 
   def multi(filter, keys)
+    return Hash.new if keys.empty?
+
     Hash[keys.zip(execute('m', filter, *keys).split(' ').map{|r| r == 'Yes'})]
   end
-  
+
   def any?(filter, keys)
+    return false if keys.empty?
+
     !!(execute('m', filter, *keys) =~ /Yes/)
   end
 
   def all?(filter, keys)
+    return true if keys.empty?
+
     !!(execute('m', filter, *keys) !~ /No/)
   end
 
@@ -64,6 +70,8 @@ class Bloomrb
   end
 
   def bulk(filter, keys)
+    return "" if keys.empty?
+
     execute('b', filter, *keys)
   end
 

--- a/test/test_bloomrb.rb
+++ b/test/test_bloomrb.rb
@@ -77,6 +77,12 @@ class BloomrbTest < Test::Unit::TestCase
                    @bloom.multi('foobar', [:fookey1, :fookey2, :fookey3]))
     end
 
+    should "return empty hash when no keys provided to multi" do
+      @socket.expects(:puts).never
+
+      assert_equal Hash.new, @bloom.multi('foobar', [])
+    end
+
     should "check if any of the keys are there" do
       @socket.expects(:puts).with("m foobar fookey1 fookey2 fookey3")
       @socket.expects(:gets).returns("No Yes No")
@@ -84,11 +90,23 @@ class BloomrbTest < Test::Unit::TestCase
       assert_equal true, @bloom.any?('foobar', [:fookey1, :fookey2, :fookey3])
     end
 
+    should "return false when no keys provided to any?" do
+      @socket.expects(:puts).never
+
+      assert_equal false, @bloom.any?('foobar', [])
+    end
+
     should "check if all of the keys are there" do
       @socket.expects(:puts).with("m foobar fookey1 fookey2 fookey3")
       @socket.expects(:gets).returns("No Yes No")
 
       assert_equal false, @bloom.all?('foobar', [:fookey1, :fookey2, :fookey3])
+    end
+
+    should "return true when no keys provided to all?" do
+      @socket.expects(:puts).never
+
+      assert_equal true, @bloom.all?('foobar', [])
     end
 
     should "set a key" do
@@ -103,6 +121,12 @@ class BloomrbTest < Test::Unit::TestCase
       @socket.expects(:gets).returns("No Yes No")
 
       assert_equal 'No Yes No', @bloom.bulk('foobar', [:fookey1, :fookey2, :fookey3])
+    end
+
+    should "return empty string when no keys provided to bulk" do
+      @socket.expects(:puts).never
+
+      assert_equal "", @bloom.bulk('foobar', [])
     end
 
     should "return an info hash" do


### PR DESCRIPTION
The return value for all? and any? is similar to one exposed by array.
