### PR TITLE
If retries equals one, then we should retry exactly once, so we actually try to use the socket twice.

### DIFF
--- a/lib/bloomrb.rb
+++ b/lib/bloomrb.rb
@@ -97,7 +97,7 @@ class Bloomrb
 
     cmd = args.join(' ')
     cmd += ' ' + opts.map{|k, v| "#{k}=#{v}"}.join(' ') unless opts.empty?
-    
+
     retry_count = 0
     begin
       socket.puts(cmd)
@@ -112,7 +112,7 @@ class Bloomrb
       end
       result
     rescue Errno::ECONNRESET, Errno::ECONNABORTED, Errno::ECONNREFUSED, Errno::EPIPE
-      raise if (retry_count += 1) >= retries
+      raise if (retry_count += 1) > retries
       @socket = nil
       sleep(1)
       retry

--- a/test/test_bloomrb.rb
+++ b/test/test_bloomrb.rb
@@ -170,6 +170,16 @@ class BloomrbTest < Test::Unit::TestCase
       assert_equal false, @bloom.set('foobar', :fookey)
     end
 
+    should "retry exactly once if retries equals one" do
+      @bloom.retries = 1
+
+      @bloom.expects(:sleep).once.with(1)
+      @socket.expects(:puts).twice.with("s foobar fookey")
+      @socket.expects(:gets).twice.raises(Errno::ECONNRESET).then.returns("No")
+
+      assert_equal false, @bloom.set('foobar', :fookey)
+    end
+
     should "not retry if retries set to 0" do
       @bloom.retries = 0
 
@@ -182,9 +192,9 @@ class BloomrbTest < Test::Unit::TestCase
     end
 
     should "raise after 5 retries" do
-      @bloom.expects(:sleep).times(4).with(1)
-      @socket.expects(:puts).times(5).with("s foobar fookey")
-      @socket.expects(:gets).times(5).raises(Errno::ECONNRESET)
+      @bloom.expects(:sleep).times(5).with(1)
+      @socket.expects(:puts).times(6).with("s foobar fookey")
+      @socket.expects(:gets).times(6).raises(Errno::ECONNRESET)
 
       assert_raises Errno::ECONNRESET do
         @bloom.set('foobar', :fookey)


### PR DESCRIPTION
If retries equals one, then we should retry exactly once, so we
actually try to use the socket twice.
