### PR TITLE
Set TCP_NODELAY flag in TCP socket

### DIFF
--- a/bloomrb.gemspec
+++ b/bloomrb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bloomrb'
-  s.version     = '0.0.3'
+  s.version     = '0.0.4'
   s.date        = '2012-10-11'
   s.summary     = "Ruby client for bloomd"
   s.description = "Wraps the bloomd protocol for usage in ruby projects"

--- a/lib/bloomrb.rb
+++ b/lib/bloomrb.rb
@@ -10,7 +10,9 @@ class Bloomrb
   end
 
   def socket
-    @socket ||= TCPSocket.new(host, port)
+    @socket ||= TCPSocket.new(host, port).tap do |socket|
+      socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+    end
   end
 
   def disconnect
@@ -97,7 +99,7 @@ class Bloomrb
 
     cmd = args.join(' ')
     cmd += ' ' + opts.map{|k, v| "#{k}=#{v}"}.join(' ') unless opts.empty?
-    
+
     retry_count = 0
     begin
       socket.puts(cmd)


### PR DESCRIPTION
When we send small package of data by default 
socket waits up to 40ms to get more data before it
sends it.